### PR TITLE
RDKE-603 : Trigger RED state IARM event from FW Dwnl

### DIFF
--- a/IARM_event_sender.c
+++ b/IARM_event_sender.c
@@ -57,7 +57,8 @@ static struct eventList{
     {"FirmwareStateEvent",IARM_BUS_SYSMGR_SYSSTATE_FIRMWARE_UPDATE_STATE},
     {"IpmodeEvent",IARM_BUS_SYSMGR_SYSSTATE_IP_MODE},
     {"usbdetected",IARM_BUS_SYSMGR_SYSSTATE_USB_DETECTED},
-    {"LogUploadEvent",IARM_BUS_SYSMGR_SYSSTATE_LOG_UPLOAD}
+    {"LogUploadEvent",IARM_BUS_SYSMGR_SYSSTATE_LOG_UPLOAD},
+    {"RedStateEvent",IARM_BUS_SYSMGR_SYSSTATE_RED_RECOV_UPDATE_STATE}
 };
 
 #define EVENT_INTRUSION "IntrusionEvent"


### PR DESCRIPTION
Reason for change: create an IARM event for RED state
Test Procedure: Validate Red Recovery dwnld
Risks: Low
Priority: P1

Change-Id: Ia42c25e25abae7b2f2a377c89dc9ef91cbb10ab3
Signed-off-by: achell415 <Anantha_Chelladurai@comcast.com>
(cherry picked from commit c1debf849ecfa5971aae0bd5117c12fa1abb4cfb)